### PR TITLE
Improved semester detection

### DIFF
--- a/js/sidingpls.js
+++ b/js/sidingpls.js
@@ -37,7 +37,7 @@ function getHomepageIRI(){
 		y--;
 		m=1<<4;
 	}
-	var s = 1 + Math.floor(m>>3);
+	var s = Math.ceil(m / 6);
 	return "https://intrawww.ing.puc.cl/siding/dirdes/ingcursos/cursos/index.phtml?per_lista_cursos=2" + s + "_" + y + "&acc_inicio=mis_cursos";
 }
 


### PR DESCRIPTION
This commit improves the semester detection algorithm. 

The current fails in August, when the value of `m` is 7. In this month, the semester should be `2` instead of `1`.